### PR TITLE
Prevent `Object must be a Date, DateTime or Time object` errors

### DIFF
--- a/i18n_filter.rb
+++ b/i18n_filter.rb
@@ -7,6 +7,7 @@ module Jekyll
     def localize(input, format=nil)
       load_translations
       format = (format =~ /^:(\w+)/) ? $1.to_sym : format
+      input = Time.parse(input) if input.is_a?(String)
       I18n.l input, :format => format, :locale => LOCALE
     end
 


### PR DESCRIPTION
Jekyll does not convert every date field (in frontmatter at least, as far as I can tell), but I18n expects Date objects.
In case `input` is a plain string, we can parse it —just like Liquid does (https://github.com/Shopify/liquid/blob/2-6-stable/lib/liquid/standardfilters.rb#L193)